### PR TITLE
Aumenta o range de parcelamento sem acréscimo

### DIFF
--- a/src/Artistas/PagSeguro.php
+++ b/src/Artistas/PagSeguro.php
@@ -483,7 +483,7 @@ class PagSeguro extends PagSeguroClient
           'creditCardToken'                        => 'required_if:paymentMethod,creditCard',
           'installmentQuantity'                    => 'required_if:paymentMethod,creditCard|integer|between:1,18',
           'installmentValue'                       => 'required_if:paymentMethod,creditCard|numeric|between:0.00,9999999.00',
-          'noInterestInstallmentQuantity'          => 'integer|between:1,3',
+          'noInterestInstallmentQuantity'          => 'integer|between:1,18',
         ];
 
         $validator = $this->validator->make($formattedPaymentSettings, $rules);


### PR DESCRIPTION
O número de parcelas que não terão juros é informado pelo lojista, a modalidade "misto" pode ser escolhida na hora de calcular o parcelamento pelo método getInstallments (seja em JavaScript ou mesmo em PHP).

Se o lojista escolher fornecer 4x sem juros pro cliente, vai cair numa exception do validate, e isso está errado, já que ele pode fornecer até mesmo 18x sem juros pro cliente.

https://pagseguro.uol.com.br/para_seu_negocio/parcelamento.jhtml#rmcl
